### PR TITLE
Feature: Support Conditions in CSproj and Dependency Groups in nuspec

### DIFF
--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -16,5 +16,5 @@ using System.Resources;
 [assembly: AssemblyVersion("0.2.11")]
 
 // these are FYI and changed automatically
-[assembly: AssemblyFileVersion("0.2.15")]
-[assembly: AssemblyInformationalVersion("0.2.15")]
+[assembly: AssemblyFileVersion("0.2.16")]
+[assembly: AssemblyInformationalVersion("0.2.16")]

--- a/src/Umbraco.Build/NuGetVerifier.cs
+++ b/src/Umbraco.Build/NuGetVerifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -20,33 +21,40 @@ namespace Umbraco.Build
             {
                 nuspec = (NuSpec) serializer.Deserialize(reader);
             }
-            var nudeps = nuspec.Metadata.Dependencies;
+            var groups = nuspec.Metadata.Groups;
+
             var deps = new List<Dependency>();
-            foreach (var nudep in nudeps)
+            foreach (var group in groups)
             {
-                var dep = new Dependency { Id = nudep.Id };
-
-                var parts = nudep.Version.Split(',');
-                if (parts.Length == 1)
+                var nudeps = group.Dependencies;
+           
+                foreach (var nudep in nudeps)
                 {
-                    dep.MinInclude = parts[0].StartsWith("[");
-                    dep.MaxInclude = parts[0].EndsWith("]");
+                    var dep = new Dependency { Id = nudep.Id };
 
-                    if (!NuGetVersion.TryParse(parts[0].Substring(1, parts[0].Length - 2).Trim(), out var version)) continue;
-                    dep.MinVersion = dep.MaxVersion = version;
-                }
-                else
-                {
-                    if (!NuGetVersion.TryParse(parts[0].Substring(1).Trim(), out var version)) continue;
-                    dep.MinVersion = version;
-                    if (!NuGetVersion.TryParse(parts[1].Substring(0, parts[1].Length - 1).Trim(), out version)) continue;
-                    dep.MaxVersion = version;
-                    dep.MinInclude = parts[0].StartsWith("[");
-                    dep.MaxInclude = parts[1].EndsWith("]");
-                }
+                    var parts = nudep.Version.Split(',');
+                    if (parts.Length == 1)
+                    {
+                        dep.MinInclude = parts[0].StartsWith("[");
+                        dep.MaxInclude = parts[0].EndsWith("]");
 
-                deps.Add(dep);
+                        if (!NuGetVersion.TryParse(parts[0].Substring(1, parts[0].Length - 2).Trim(), out var version)) continue;
+                        dep.MinVersion = dep.MaxVersion = version;
+                    }
+                    else
+                    {
+                        if (!NuGetVersion.TryParse(parts[0].Substring(1).Trim(), out var version)) continue;
+                        dep.MinVersion = version;
+                        if (!NuGetVersion.TryParse(parts[1].Substring(0, parts[1].Length - 1).Trim(), out version)) continue;
+                        dep.MaxVersion = version;
+                        dep.MinInclude = parts[0].StartsWith("[");
+                        dep.MaxInclude = parts[1].EndsWith("]");
+                    }
+
+                    deps.Add(dep);
+                }
             }
+            
             return deps.ToArray();
         }
 
@@ -66,7 +74,7 @@ namespace Umbraco.Build
                     ReadCsProj(csproj, l);
             }
             IEnumerable<Package> p = l.OrderBy(x => x.Id);
-            p = DistinctBy(p, x => x.Id + ":::" + x.Version);
+            p = DistinctBy(p, x => x.Id + ":::" + x.Version + ":::" + x.Codition ?? string.Empty +":::");
             return p.ToArray();
         }
 
@@ -74,17 +82,36 @@ namespace Umbraco.Build
         // returns package id -> package versions
         public IGrouping<string, Package>[] GetPackageErrors(Package[] pkgs)
         {
-            return pkgs
-              .GroupBy(x => x.Id)
-              .Where(x => x.Count() > 1)
-              .ToArray();
+
+            var conditions = pkgs.GroupBy(x => x.Codition);
+            
+            var conditionLess = pkgs.Where(x => x.Codition is null).ToArray();
+
+            IGrouping<string, Package>[] result = null;
+            
+            foreach (var condition in conditions)
+            {
+                var temp = condition.Key is null ? condition : condition.Concat(conditionLess);
+
+                var supResult =
+                        temp
+                        .GroupBy(x =>  x.Id)
+                    .Where(x => x.Count() > 1)
+                    .ToArray();
+
+
+                    result = result is null ? supResult : result.Concat(supResult).ToArray();
+            }
+
+            return result;
+
         }
 
         // look for nuspec dependencies that don't match packages
         // returns dependency, package version
         public NuGetError[] GetNuSpecErrors(Package[] pkgs, Dependency[] deps)
         {
-            var xpkgs = pkgs.ToDictionary(x => x.Id, x => x.Version);
+            var xpkgs = pkgs.ToDictionary(x => x.Id + ":::" + x.Codition, x => x.Version);
             return deps.Select(dep =>
             {
                 if (!xpkgs.TryGetValue(dep.Id, out var packageVersion)) return null;
@@ -128,11 +155,16 @@ namespace Umbraco.Build
             {
                 proj = (CsProjProject) serializer.Deserialize(reader);
             }
-            foreach (var p in proj.ItemGroups.Where(x => x.Packages != null).SelectMany(x => x.Packages))
+
+            foreach (var itemGroup in proj.ItemGroups)
             {
-                var sversion = p.VersionE ?? p.VersionA;
-                if (!NuGetVersion.TryParse(sversion, out var version)) continue;
-                packages.Add(new Package { Id = p.Id, Version = version, Project = GetDirectoryName(filename) });
+                if (itemGroup.Packages != null)
+                    foreach (var package in itemGroup.Packages)
+                    {
+                        var sversion = package.VersionE ?? package.VersionA;
+                        if (!NuGetVersion.TryParse(sversion, out var version)) continue;
+                        packages.Add(new Package { Id = package.Id, Version = version, Project = GetDirectoryName(filename), Codition = itemGroup.Condition});
+                    }
             }
         }
 
@@ -182,6 +214,8 @@ namespace Umbraco.Build
             public string Id { get; set; }
             public NuGetVersion Version { get; set; }
             public string Project { get; set; }
+
+            public string Codition{ get; set; }
         }
 
         [XmlType(AnonymousType = true /*, Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"*/)]
@@ -196,11 +230,22 @@ namespace Umbraco.Build
         public class NuSpecMetadata
         {
             [XmlArray("dependencies")]
-            [XmlArrayItem("dependency", IsNullable = false)]
-            public NuSpecDependency[] Dependencies { get; set; }
+            [XmlArrayItem("group", IsNullable = false)]
+            public NuSpecDependencyGroup[] Groups { get; set; }
+           
         }
 
-        [XmlType(AnonymousType = true, /*Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd",*/ TypeName = "dependencies")]
+        [XmlType(AnonymousType = true, /*Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd",*/ TypeName = "group")]
+        public class NuSpecDependencyGroup
+        {
+            [XmlElement("dependency")]
+            public NuSpecDependency[] Dependencies { get; set; }
+            
+            [XmlAttribute(AttributeName = "targetFramework")]
+            public string TargetFramework { get; set; }
+        }
+        
+        [XmlType(AnonymousType = true, /*Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd",*/ TypeName = "dependency")]
         public class NuSpecDependency
         {
             [XmlAttribute(AttributeName = "id")]
@@ -241,6 +286,10 @@ namespace Umbraco.Build
         {
             [XmlElement("PackageReference")]
             public CsProjPackageReference[] Packages { get; set; }
+            
+            [XmlAttribute(AttributeName = "Condition")]
+            public string Condition { get; set; }
+
         }
 
         [XmlType(AnonymousType = true, TypeName = "PackageReference")]
@@ -256,4 +305,6 @@ namespace Umbraco.Build
             public string VersionE { get; set; }
         }
     }
+
+
 }

--- a/src/Umbraco.Build/NuGetVerifier.cs
+++ b/src/Umbraco.Build/NuGetVerifier.cs
@@ -74,7 +74,7 @@ namespace Umbraco.Build
                     ReadCsProj(csproj, l);
             }
             IEnumerable<Package> p = l.OrderBy(x => x.Id);
-            p = DistinctBy(p, x => x.Id + ":::" + x.Version + ":::" + x.Codition ?? string.Empty +":::");
+            p = DistinctBy(p, x => x.Id + ":::" + x.Version + ":::" + x.Condition ?? string.Empty +":::");
             return p.ToArray();
         }
 
@@ -83,9 +83,9 @@ namespace Umbraco.Build
         public IGrouping<string, Package>[] GetPackageErrors(Package[] pkgs)
         {
 
-            var conditions = pkgs.GroupBy(x => x.Codition);
+            var conditions = pkgs.GroupBy(x => x.Condition);
             
-            var conditionLess = pkgs.Where(x => x.Codition is null).ToArray();
+            var conditionLess = pkgs.Where(x => x.Condition is null).ToArray();
 
             IGrouping<string, Package>[] result = null;
             
@@ -111,7 +111,7 @@ namespace Umbraco.Build
         // returns dependency, package version
         public NuGetError[] GetNuSpecErrors(Package[] pkgs, Dependency[] deps)
         {
-            var xpkgs = pkgs.ToDictionary(x => x.Id + ":::" + x.Codition, x => x.Version);
+            var xpkgs = pkgs.ToDictionary(x => x.Id + ":::" + x.Condition, x => x.Version);
             return deps.Select(dep =>
             {
                 if (!xpkgs.TryGetValue(dep.Id, out var packageVersion)) return null;
@@ -163,7 +163,7 @@ namespace Umbraco.Build
                     {
                         var sversion = package.VersionE ?? package.VersionA;
                         if (!NuGetVersion.TryParse(sversion, out var version)) continue;
-                        packages.Add(new Package { Id = package.Id, Version = version, Project = GetDirectoryName(filename), Codition = itemGroup.Condition});
+                        packages.Add(new Package { Id = package.Id, Version = version, Project = GetDirectoryName(filename), Condition = itemGroup.Condition});
                     }
             }
         }
@@ -215,7 +215,7 @@ namespace Umbraco.Build
             public NuGetVersion Version { get; set; }
             public string Project { get; set; }
 
-            public string Codition{ get; set; }
+            public string Condition{ get; set; }
         }
 
         [XmlType(AnonymousType = true /*, Namespace = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"*/)]


### PR DESCRIPTION
### Notes
- Add support for conditions in *.csproj
  - E.g. https://github.com/umbraco/Umbraco-CMS/blob/fe8421a3b03bdbc074504c848692c95b0a7db269/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj#L31
- Add support for groups in *.nuspec
   - E.g. https://github.com/umbraco/Umbraco-CMS/blob/fe8421a3b03bdbc074504c848692c95b0a7db269/build/NuSpecs/UmbracoCms.Web.nuspec#L20
  - I'm pretty sure this has never worked for v8, as we always use groups and not having dependencies directly under the `dependencies` section - dependencies https://github.com/umbraco/Umbraco-CMS/blob/e4c501075925191b370cf049369cf536d6ace1ab/build/NuSpecs/UmbracoCms.Web.nuspec#L20


### Tests
- I uploaded the build of this to the following myget feed https://www.myget.org/F/umbracoprereleases/api/v3/index.json.
- To test this, you need to set this feed in the `build-bootstrap.ps1` and ensure the caches are deleted (temp folders)
    - I already tested this and use the feed for this branch https://github.com/umbraco/Umbraco-CMS/tree/netcore/feature/multitarget-dotnet5
    - The commit can be seen here https://github.com/umbraco/Umbraco-CMS/commit/a6503f65c95fbb7a2cfd68447395f9ac05bf1193

I already tested for v8 and netcore, and the build script works.

### Release
- When this is merged, we need to release a new version to the Myget feed "https://www.myget.org/F/umbracocore/api/v3/index.json"
