### PR TITLE
Updated the Get/Set UmbracoVersion to support the .NET Core format

### DIFF
--- a/ps/GetUmbracoVersion.ps1
+++ b/ps/GetUmbracoVersion.ps1
@@ -1,10 +1,22 @@
-
 $ubuild.DefineMethod("GetUmbracoVersion",
 {
   # parse SolutionInfo and retrieve the version string
   $filepath = "$($this.SolutionRoot)\src\SolutionInfo.cs"
-  $text = [System.IO.File]::ReadAllText($filepath)
-  $match = [System.Text.RegularExpressions.Regex]::Matches($text, "AssemblyInformationalVersion\(`"(.+)?`"\)")
+
+  $solutionInfoExists = [System.IO.File]::Exists($filepath)
+
+  if ($solutionInfoExists) 
+  {
+    $text = [System.IO.File]::ReadAllText($filepath)
+    $match = [System.Text.RegularExpressions.Regex]::Matches($text, "AssemblyInformationalVersion\(`"(.+)?`"\)")
+  }
+  else
+  {
+    $filepath = "$($this.SolutionRoot)\src\Directory.Build.props"
+    $text = [System.IO.File]::ReadAllText($filepath)
+    $match = [System.Text.RegularExpressions.Regex]::Matches($text, "<InformationalVersion>(.+)?<\/InformationalVersion>")
+  }
+  
   $version = $match.Groups[1].ToString()
 
   # clear

--- a/ps/SetUmbracoVersion.ps1
+++ b/ps/SetUmbracoVersion.ps1
@@ -35,19 +35,49 @@ $ubuild.DefineMethod("SetUmbracoVersion",
   #
   $release = "" + $semver.Major + "." + $semver.Minor + "." + $semver.Patch
 
-  # edit files and set the proper versions and dates
-  Write-Host "Update SolutionInfo.cs"
-  $this.ReplaceFileText("$($this.SolutionRoot)\src\SolutionInfo.cs", `
-    "AssemblyFileVersion\(`".+`"\)", `
-    "AssemblyFileVersion(`"$release`")")
-  $this.ReplaceFileText("$($this.SolutionRoot)\src\SolutionInfo.cs", `
-    "AssemblyInformationalVersion\(`".+`"\)", `
-    "AssemblyInformationalVersion(`"$semver`")")
-  $year = [System.DateTime]::Now.ToString("yyyy")
-  $this.ReplaceFileText("$($this.SolutionRoot)\src\SolutionInfo.cs", `
-    "AssemblyCopyright\(`"Copyright © Umbraco (\d{4})`"\)", `
-    "AssemblyCopyright(`"Copyright © Umbraco $year`")")
+  $filePath = "$($this.SolutionRoot)\src\SolutionInfo.cs"
+  $solutionInfoExists = [System.IO.File]::Exists($filepath)
+  if($solutionInfoExists)
+  {
+    # edit files and set the proper versions and dates
+    Write-Host "Update SolutionInfo.cs"
+    $this.ReplaceFileText($filePath, `
+      "AssemblyFileVersion\(`".+`"\)", `
+      "AssemblyFileVersion(`"$release`")")
+    $this.ReplaceFileText($filePath, `
+      "AssemblyInformationalVersion\(`".+`"\)", `
+      "AssemblyInformationalVersion(`"$semver`")")
+    $year = [System.DateTime]::Now.ToString("yyyy")
+    $this.ReplaceFileText($filePath, `
+      "AssemblyCopyright\(`"Copyright © Umbraco (\d{4})`"\)", `
+      "AssemblyCopyright(`"Copyright © Umbraco $year`")")
+  }else{
+    $filePath = "$($this.SolutionRoot)\src\Directory.Build.props"
 
+    # edit files and set the proper versions and dates
+    Write-Host "Update Directory.Build.props"
+    $this.ReplaceFileText($filePath, `
+      "<Version>(.+)?</Version>", `
+      "<Version>$release</Version>")
+
+    $this.ReplaceFileText($filePath, `
+      "<AssemblyVersion>(.+)?</AssemblyVersion>", `
+      "<AssemblyVersion>$release</AssemblyVersion>")
+
+    $this.ReplaceFileText($filePath, `
+      "<InformationalVersion>(.+)?</InformationalVersion>", `
+      "<InformationalVersion>$semver</InformationalVersion>")
+
+
+    $this.ReplaceFileText($filePath, `
+      "<FileVersion>(.+)?</FileVersion>", `
+      "<FileVersion>$release</FileVersion>")    
+    $year = [System.DateTime]::Now.ToString("yyyy")
+
+    $this.ReplaceFileText($filePath, `
+      "<Copyright>(.+)?</Copyright>", `
+      "<Copyright>Copyright " + [char]0x00A9 + " Umbraco $year</Copyright>")
+  }
   $this.Version = @{
     Semver = $semver
     Release = $release

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -16,5 +16,5 @@ using System.Resources;
 [assembly: AssemblyVersion("0.2.11")]
 
 // these are FYI and changed automatically
-[assembly: AssemblyFileVersion("0.2.16")]
-[assembly: AssemblyInformationalVersion("0.2.16")]
+[assembly: AssemblyFileVersion("0.2.17")]
+[assembly: AssemblyInformationalVersion("0.2.17")]


### PR DESCRIPTION
Added backwards-compatible support for not having a `SolutionInfo.cs` but instead a `Directory.Build.props`

So basically updated the `GetUmbracoVersion` and `SetUmbracoVersion` to support the .NET Core format `Directory.Build.props`


### Test
- Just ensure it still works for v8
  - In this project root run `powershell .\build\build.ps1`
  - In umbraco core `build-bootstrap.ps1` update `$nugetsourceUmbraco`  to point to Umbraco.Build's  "\build.out"
  - Run  `powershell .\build\build.ps1` in umbraco core