### PR TITLE
Pinned Semver version to ensure we have consistent dependency for builds

### DIFF
--- a/ps/GetUmbracoBuildEnv.ps1
+++ b/ps/GetUmbracoBuildEnv.ps1
@@ -136,7 +136,7 @@ $ubuild.DefineMethod("GetUmbracoBuildEnv",
       if (-not (test-path $semver))
       {
         Write-Host "Download Semver..."
-        $params = "-OutputDirectory", $scriptTemp, "-Verbosity", "quiet", "-Source", $nugetsource
+        $params = "-Version", "2.3.0", "-OutputDirectory", $scriptTemp, "-Verbosity", "quiet", "-Source", $nugetsource
         &$nuget install semver @params
         $dir = ls "$scriptTemp\semver.*" | sort -property Name -descending | select -first 1
         $file = "$dir\lib\net452\Semver.dll"
@@ -233,7 +233,7 @@ $ubuild.DefineMethod("GetUmbracoBuildEnv",
     $vsVersions = new-object System.Collections.Generic.List[System.Version]
 
     Write-Host "Finding MSbuild.exe"
-    
+
     # parse vswhere output
     $params = @()
     if ($options.VsPreview) { $params += "-prerelease" }
@@ -254,9 +254,9 @@ $ubuild.DefineMethod("GetUmbracoBuildEnv",
       }
     }
     if ($vsIx2 -ge 0) {
-      
+
       Write-Host "Detected VS version " $vsVersion.Major
-      
+
       $vsPath = $vsPaths[$vsIx2]
 
       if ($vsVersion.Major -gt 16) {
@@ -282,7 +282,7 @@ $ubuild.DefineMethod("GetUmbracoBuildEnv",
         MsBuild = "$msBuild\MsBuild.exe"
         ToolsVersion = $toolsVersion
       }
-     
+
       Write-Host "Using MsBuild.exe in $msBuild\MsBuild.exe"
     }
   }

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -16,5 +16,5 @@ using System.Resources;
 [assembly: AssemblyVersion("0.2.11")]
 
 // these are FYI and changed automatically
-[assembly: AssemblyFileVersion("0.2.18")]
-[assembly: AssemblyInformationalVersion("0.2.18")]
+[assembly: AssemblyFileVersion("0.2.19")]
+[assembly: AssemblyInformationalVersion("0.2.19")]

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -16,5 +16,5 @@ using System.Resources;
 [assembly: AssemblyVersion("0.2.11")]
 
 // these are FYI and changed automatically
-[assembly: AssemblyFileVersion("0.2.19")]
-[assembly: AssemblyInformationalVersion("0.2.19")]
+[assembly: AssemblyFileVersion("0.3.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]

--- a/src/Umbraco.Build.Tests/Umbraco.Build.Tests.csproj
+++ b/src/Umbraco.Build.Tests/Umbraco.Build.Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Umbraco.Build.Tests</RootNamespace>
     <AssemblyName>Umbraco.Build.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Umbraco.Build/Umbraco.Build.csproj
+++ b/src/Umbraco.Build/Umbraco.Build.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Umbraco.Build</RootNamespace>
     <AssemblyName>Umbraco.Build</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I ran into a problem today looking to build the Umbraco.Licensing component that still uses this dependency for build.

As you can see [here](https://dev.azure.com/umbraco/Umbraco.Licensing/_build?definitionId=311&_a=summary) - builds have started failing (and also fail if I try to rebuild a previously successful one).

Error in the logs is:

```
Failed to locate D:\a\1\s\build\temp\Semver.3.0.0\lib\net452\Semver.dll
```

I found the issue in that there's recently been a [new release of Semver](https://www.nuget.org/packages/Semver), which doesn't ship the dll in the place we are expecting it to be.  It's also a new major version.

We are currently installing without specifying a version, so in this PR I've pinned it to the one we've been getting automatically by installing the latest for the past several years.

---

I also found the project wouldn't build as it depended on .NET Framework 4.6.1, so I've also updated this to 4.8.